### PR TITLE
Touch up some wording, update links and examples to be v5

### DIFF
--- a/docs/introduction/jda.md
+++ b/docs/introduction/jda.md
@@ -1,7 +1,7 @@
 # JDA (Java Discord API)
 JDA strives to provide a clean and full wrapping of the Discord REST API and its Websocket-Events for Java.
 
-If you have any suggestions/questions/feedback for this wiki please contact Minn#6688 or DV8FromTheWorld#6297 via [Discord](https://discord.gg/0hMr4ce0tIk3pSjp)
+If you have any suggestions/questions/feedback for this wiki, please visit the #wiki-dev channel in the [JDA Discord Server](https://discord.gg/0hMr4ce0tIk3pSjp)
 
 !!! example "Examples"
     ```java
@@ -56,14 +56,14 @@ If you have any suggestions/questions/feedback for this wiki please contact Minn
 You can get the latest released builds here:
 [Promoted Downloads](https://github.com/DV8FromTheWorld/JDA/releases)
 
-If you want the most up-to-date builds, you can get them here: [Latest Build Downloads](https://ci.dv8tion.net/job/JDA/)
+If you want the most up-to-date builds, you can get them here: [Latest Build Downloads](https://ci.dv8tion.net/job/JDA5/)
 
 ## Docs
 Javadocs are available in both jar format and web format.<br>
 The jar format is available on the [Promoted Downloads](https://github.com/DV8FromTheWorld/JDA/releases) page or on any of the
-build pages of the [Downloads](https://ci.dv8tion.net/job/JDA/).<br>
+build pages of the [legacy v4 Downloads](https://ci.dv8tion.net/job/JDA/) or [v5 Downloads](https://ci.dv8tion.net/job/JDA5/).<br>
 <br>
-The web format allows for viewing of the [Latest Docs](https://ci.dv8tion.net/job/JDA/javadoc/)
+The web format allows for viewing of the [Latest Docs](https://ci.dv8tion.net/job/JDA5/javadoc/) or [legacy Docs](https://ci.dv8tion.net/job/JDA/javadoc/) 
 and also viewing of each individual build's javadoc. To view the javadoc for a specific build, you will need to go to that build's page
 on [the build server](https://ci.dv8tion.net/job/JDA/) and download the javadoc jar for the specific build.<br>
 A shortcut would be: `https://ci.dv8tion.net/job/JDA/BUILD_NUMBER_GOES_HERE`, you just need to replace the 
@@ -75,12 +75,13 @@ If you need help, or just want to talk with the JDA or other Devs, you can join 
 
 Alternatively you can also join the [Unofficial Discord API Guild](https://discord.gg/discord-api).
 Once you joined, you can find JDA-specific help in the `#java_jda` channel.
+The JDA specific server will often have faster responses than the `#java_jda` channel in the Discord API server.
 
 For guides and setup help you can also take a look at this wiki.
 <br>Especially interesting are the [Getting Started](../using-jda/getting-started.md) Pages.
 
 ## Contributing to JDA
-If you want to contribute to JDA, make sure to base your branch off of our **development** branch (or a feature-branch)
+If you want to contribute to JDA, make sure to base your branch off of our **master** branch (or a feature-branch)
 and create your PR into that **same** branch. **We will be rejecting any PRs between branches or into release branches!**
 
 It is also highly recommended to get in touch with the Devs before opening Pull Requests (either through an issue or the Discord servers mentioned above).<br>
@@ -90,4 +91,4 @@ More information can be found at the wiki page [Contributing](../contributing/co
 
 ## Dependencies
 This project requires **Java 8**.<br>
-For other dependencies, see [README](https://github.com/DV8FromTheWorld/JDA/tree/master/README.md)
+For other dependencies, see [README](https://github.com/DV8FromTheWorld/JDA5/tree/master/README.md)

--- a/docs/using-jda/gateway-intents-and-member-cache-policy.md
+++ b/docs/using-jda/gateway-intents-and-member-cache-policy.md
@@ -1,21 +1,21 @@
-[GatewayIntent]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/requests/GatewayIntent.html
-[createDefault]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/JDABuilder.html#createDefault(java.lang.String)
-[createLight]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/JDABuilder.html#createLight(java.lang.String)
-[create]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/JDABuilder.html#create(java.lang.String,net.dv8tion.jda.api.requests.GatewayIntent,net.dv8tion.jda.api.requests.GatewayIntent...)
-[CacheFlag]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/utils/cache/CacheFlag.html
-[GatewayIntent.DEFAULT]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/requests/GatewayIntent.html#DEFAULT
-[enableCache]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/JDABuilder.html#enableCache(net.dv8tion.jda.api.utils.cache.CacheFlag,net.dv8tion.jda.api.utils.cache.CacheFlag...)
-[disableCache]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/JDABuilder.html#disableCache(net.dv8tion.jda.api.utils.cache.CacheFlag,net.dv8tion.jda.api.utils.cache.CacheFlag...)
-[enableIntents]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/JDABuilder.html#enableIntents(net.dv8tion.jda.api.requests.GatewayIntent,net.dv8tion.jda.api.requests.GatewayIntent...)
-[MemberCachePolicy]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/utils/MemberCachePolicy.html
-[setMemberCachePolicy]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/JDABuilder.html#setMemberCachePolicy(net.dv8tion.jda.api.utils.MemberCachePolicy)
-[loadMembers]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Guild.html#loadMembers()
+[GatewayIntent]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/requests/GatewayIntent.html
+[createDefault]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/JDABuilder.html#createDefault(java.lang.String)
+[createLight]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/JDABuilder.html#createLight(java.lang.String)
+[create]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/JDABuilder.html#create(java.lang.String,net.dv8tion.jda.api.requests.GatewayIntent,net.dv8tion.jda.api.requests.GatewayIntent...)
+[CacheFlag]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/utils/cache/CacheFlag.html
+[GatewayIntent.DEFAULT]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/requests/GatewayIntent.html#DEFAULT
+[enableCache]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/JDABuilder.html#enableCache(net.dv8tion.jda.api.utils.cache.CacheFlag,net.dv8tion.jda.api.utils.cache.CacheFlag...)
+[disableCache]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/JDABuilder.html#disableCache(net.dv8tion.jda.api.utils.cache.CacheFlag,net.dv8tion.jda.api.utils.cache.CacheFlag...)
+[enableIntents]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/JDABuilder.html#enableIntents(net.dv8tion.jda.api.requests.GatewayIntent,net.dv8tion.jda.api.requests.GatewayIntent...)
+[MemberCachePolicy]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/utils/MemberCachePolicy.html
+[setMemberCachePolicy]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/JDABuilder.html#setMemberCachePolicy(net.dv8tion.jda.api.utils.MemberCachePolicy)
+[loadMembers]: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/Guild.html#loadMembers()
 
 # Gateway Intents
 
-In version **4.2.0** we have introduced the [`GatewayIntent`][GatewayIntent] enum. This marks a change in the way bots will work in the future.
+In version **4.2.0**, we introduced the [`GatewayIntent`][GatewayIntent] enum. This marks a change in the way bots will work in the future.
 
-Discord now expects the bot to explicitly state which events the bot *intends* to use for its session. We have deprecated the old `JDABuilder` constructors to prompt the user directly with this new opt-in style of using specific features. Instead, we have introduced a number of factory methods which will apply some default settings for you:
+Building JDA is done using one of the JDABuilder factory methods, each of which has some default intents:
 
 - [`createDefault`][createDefault]
 - [`createLight`][createLight]
@@ -23,7 +23,7 @@ Discord now expects the bot to explicitly state which events the bot *intends* t
 
 ### What Intents do I need?
 
-The necessary intents directly correlate with the features you *intend* to deploy.
+The necessary intents directly correlate with the features you intend to use.
 Each [`GatewayIntent`][GatewayIntent] documents which events are enabled by it. Some caches in JDA also depend on these intents, so take a close look at the documentation for [`CacheFlag`][CacheFlag] as well.
 
 For instance, a bot that only responds to messages and sends welcome messages will only need `GUILD_MESSAGES` and `GUILD_MEMBERS`. A bot like this doesn't rely on any members being cached, so the right solution is to use [`createLight`][createLight] which will disable all [`CacheFlags`][CacheFlag] and member caching.
@@ -103,7 +103,7 @@ We also provide a few reasonable implementations to choose from and apply using 
 - [Owner](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/utils/MemberCachePolicy.html#OWNER)
     Will keep the guild owner cached
 - [Pending](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/utils/MemberCachePolicy.html#PENDING)
-    Will keep the members cached, which have not passed membership screening yet (requires `GUILD_MEMBERS` intents)
+    Will cache the members which have not passed membership screening yet (requires `GUILD_MEMBERS` intents)
 - [None](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/utils/MemberCachePolicy.html#NONE)
     Will only keep the self member cached and nobody else
 
@@ -123,13 +123,15 @@ This cache will grow over time by loading members when they are active in the gu
 
 We offer a number of ways to load and cache members:
 
-- [Guild.retrieveMembersByPrefix(String, int)](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Guild.html#retrieveMembersByPrefix(java.lang.String,int))
-- [Guild.retrieveOwner()](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Guild.html#retrieveOwner())
-- [Guild.retrieveMemberById(long|String)](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Guild.html#retrieveMemberById(long))
-- [Guild.retrieveMembersByIds(long...|String..)](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Guild.html#retrieveMembersByIds(long...))
-- [Guild.retrieveMembers(Collection&lt;User>)](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Guild.html#retrieveMembers(java.util.Collection))
-- [Message.getMember()](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Message.html#getMember()) (from events)
+- [Guild.retrieveMembersByPrefix(String, int)](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/Guild.html#retrieveMembersByPrefix(java.lang.String,int))
+- [Guild.retrieveOwner()](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/Guild.html#retrieveOwner())
+- [Guild.retrieveMemberById(long|String)](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/Guild.html#retrieveMemberById(long))
+- [Guild.retrieveMembersByIds(long...|String..)](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/Guild.html#retrieveMembersByIds(long...))
+- [Guild.retrieveMembers(Collection&lt;User>)](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/Guild.html#retrieveMembers(java.util.Collection))
+- [Message.getMember()](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/Message.html#getMember()) (from events)
 
 All of these methods will load the members from cache or fallback to requesting them from the Discord API.
 
 You can also load the entire member list at runtime by using [`loadMembers`][loadMembers], however this requires the privileged `GUILD_MEMBERS` intent. This process is called *guild member chunking* (aka chunking).
+
+Chunking can also be performed for many guilds at startup automatically, by using `setChunkingFilter` on the JDABuilder.  This also requires the `GUILD_MEMBERS` intent

--- a/docs/using-jda/getting-started.md
+++ b/docs/using-jda/getting-started.md
@@ -27,8 +27,11 @@
     
     ![client id](https://i.imgur.com/lsygf0X.png)
 
-2. Create an OAuth2 authorization URL (reference [docs](https://discord.com/developers/docs/topics/oauth2#bot-authorization-flow))
-    **Example**: `https://discord.com/api/oauth2/authorize?client_id=492747769036013578&scope=bot`
+2. Create an OAuth2 authorization URL (reference [docs](https://discord.com/developers/docs/topics/oauth2#bot-authorization-flow)).
+    Users who want to use Interaction Commands should also add the `applications.commands` scope.
+    Some example URLs:
+      - `https://discord.com/api/oauth2/authorize?client_id=492747769036013578&scope=bot`
+      - `https://discord.com/api/oauth2/authorize?client_id=492747769036013578&scope=bot+applications.commands`
 
     !!! note 
         This can be done from the **Bot** tab at the very bottom. Here you can select the scope **bot** and some permissions required for your bots functionality (optional).
@@ -55,7 +58,7 @@
     
     [ ![Download](https://shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fm2.dv8tion.net%2Freleases%2Fnet%2Fdv8tion%2FJDA%2Fmaven-metadata.xml&color=informational&label=Download&style=for-the-badge) ](https://ci.dv8tion.net/job/JDA/lastSuccessfulBuild/)
 
-3. Create [`JDABuilder`](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/JDABuilder.html) instance with token
+3. Create [`JDABuilder`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/JDABuilder.html) instance with token
 4. Build JDA using `JDABuilder.build()`
     
     ```java
@@ -64,6 +67,8 @@
         JDA api = JDABuilder.createDefault(BOT_TOKEN).build();
     }
     ```
+    !!! tip
+        It is often better to load your token in from an external file or environment variable, especially if you plan on publishing the source code.
 
 ## Making a Ping-Pong Protocol
 
@@ -91,7 +96,7 @@
     }
     ```
     !!! info
-        More information about [RestAction](using-restaction.md)
+        More information about RestActions can be found [here](using-restaction.md)
 
 
 3. Register your listener with either `JDABuilder.addEventListeners(new MyListener())` or `JDA.addEventListeners(new MyListener())` (see [Events](../introduction/events.md))

--- a/docs/using-jda/making-a-music-bot.md
+++ b/docs/using-jda/making-a-music-bot.md
@@ -52,11 +52,12 @@ public class MusicBot extends ListenerAdapter
             .addEventListeners(new MusicBot()) // Register new MusicBot instance as EventListener
             .build(); // Build JDA - connect to discord
     }
-
-    // Note that we are using GuildMessageReceivedEvent to only include messages from a Guild!
+    
     @Override
-    public void onGuildMessageReceived(GuildMessageReceivedEvent event) 
+    public void onGuildMessageReceived(MessageReceivedEvent event) 
     {
+        // Make sure we only respond to events that occur in a guild
+        if (!event.isFromGuild()) return;
         // This makes sure we only execute our code when someone sends a message with "!play"
         if (!event.getMessage().getContentRaw().startsWith("!play")) return;
         // Now we want to exclude messages from bots since we want to avoid command loops in chat!

--- a/docs/using-jda/making-a-music-bot.md
+++ b/docs/using-jda/making-a-music-bot.md
@@ -54,7 +54,7 @@ public class MusicBot extends ListenerAdapter
     }
     
     @Override
-    public void onGuildMessageReceived(MessageReceivedEvent event) 
+    public void onMessageReceived(MessageReceivedEvent event) 
     {
         // Make sure we only respond to events that occur in a guild
         if (!event.isFromGuild()) return;

--- a/docs/using-jda/separation-of-concerns.md
+++ b/docs/using-jda/separation-of-concerns.md
@@ -1,17 +1,18 @@
 # Separation of Concerns
 
 In JDA we follow the pattern of [Separation of Concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) (SoC) for our entities.
-This means that updates and moderation all happens in dedicated classes rather than on the entities themself (with a few exceptions like deletion)
+This means that updates and moderation all happens in dedicated classes rather than on the entities themselves (with a few exceptions like deletion)
 
 Each entity that can be updated directly has a [Manager](#managers) instance which can be used to update one or more of the entity properties such as its name.
 
 ## Managers
 
-The managers in JDA are useful to update entities without much complications, you can update all of the properties in a single [RestAction](using-restaction.md) execution (HTTP request).
+The managers in JDA are useful to update entities.
+Without many complications, you can update many of properties in a single [RestAction](using-restaction.md) execution (HTTP request).
 
 ### Updating an Entity
 
-We will make a small example here on how to update the name and the topic of a [TextChannel](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/TextChannel.html).
+We will make a small example here on how to update the name and the topic of a [TextChannel](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/TextChannel.html).
 
 ```java
 public void updateChannel(TextChannel channel) {
@@ -27,12 +28,94 @@ public void updateChannel(TextChannel channel) {
 
 Every manager in JDA is cached for re-use and can be updated for an interval and then executed upon command, very useful for bots!
 
-[Example-State-Machine](https://gist.github.com/MinnDevelopment/190b79109b17c3bb446eea13be57c43c)
+??? example "Example State Machine"
+    ```java
+    import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+    import net.dv8tion.jda.api.hooks.ListenerAdapter;
+    import net.dv8tion.jda.api.entities.*;
+    import net.dv8tion.jda.api.MessageBuilder;
+    import net.dv8tion.jda.api.requests.restaction.MessageAction;
+    
+    // derived with permission from https://gist.github.com/MinnDevelopment/190b79109b17c3bb446eea13be57c43c
+    public class UpdateStateMachine extends ListenerAdapter {
+    private final TextChannel channel;
+    private String name = null;
+    private String topic = null;
+    private int state = 0;
+    
+        public UpdateStateMachine(TextChannel channel) {
+            this.channel = channel;
+        }
+    
+        @Override
+        public void onMessageReceived(MessageReceivedEvent event) {
+            if (!event.isFromGuild()) return;
+            if (!event.getChannel().equals(channel)) return;
+            String content = event.getMessage().getContentRaw();
+            if (!content.startsWith("!update ")) return;
+            String parts[] = content.split(" ", 2);
+            String arguments = parts.length > 1 ? parts[1] : "";
+            switch (state) {
+                case 0: // setting mode
+                    if (arguments.equals("done")) {              // finish update
+                        state = 2; // enter update mode
+                        sendStatus().append("\nType `!update yes` to finish!").queue();
+                    } else if (arguments.equals("reset")) {      // reset state
+                        state = 1; // enter reset mode
+                        sendStatus().append("\nType `!update yes` to reset!").queue();
+                    } else if (arguments.startsWith("topic ")) { // update topic
+                        this.topic = arguments.split(" ", 2)[1];
+                        channel.getManager().setTopic(this.topic);
+                    } else if (arguments.startsWith("name ")) {  // update name
+                        this.name = arguments.split(" ", 3)[1];
+                        channel.getManager().setName(this.name);
+                    } else {
+                        channel.sendMessage("I'm sorry I did not understand.").queue();
+                    }
+                    break;
+                case 1: // reset mode
+                    state = 0;
+                    if (arguments.equals("yes"))  // we should reset
+                        resetState();
+                    else                          // nevermind, we are not done
+                        channel.sendMessage("Ok, what do you want to change?").queue();
+                    break;
+                case 2: // update mode
+                    state = 0;
+                    if (arguments.equals("yes")) // we should update
+                        channel.getManager().queue((v) -> resetState());
+                    else                         // nevermind, we are not done
+                        channel.sendMessage("Ok, what do you want to change?").queue();
+                    break;
+            }
+        }
+    
+        protected void resetState() {
+            channel.getManager().reset();
+            this.name = null;
+            this.topic = null;
+        }
+    
+        private MessageAction sendStatus() {
+            MessageBuilder builder = new MessageBuilder();
+            builder.append("**Current Status**");
+            if (name != null || topic != null) {
+                StringBuilder changes = new StringBuilder();
+                if (name != null)
+                    changes.append("name -> ").append(name).append("\n");
+                if (topic != null)
+                    changes.append("topic -> ").append(topic);
+                builder.appendCodeBlock(changes, "");
+            }
+            return builder.sendTo(channel);
+        }
+    }
+    ```
 
 ## Exceptions to SoC Pattern
 
 The only exceptions we have are deletion and creation.
-All entities are deleted directly using its delete() method, for instance [Channel.delete()](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Channel.html#delete()).
+All entities are deleted directly using its delete() method, for instance [Channel.delete()](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/Channel.html#delete()).
 
 You can create copies of entities in the same fashion with one twist. Some `createCopy()` methods allow you to modify the new copy before execution of the **RestAction**
 
@@ -46,4 +129,4 @@ public void copyChannel(Channel channel, String newName) {
 ```
 
 
-These things can be overlooked, so we do recommend to inspect the return type of these operations: `getManager()`, `create...()`, `delete()`, `ban(...)`, `kick(...)`, etc.
+These things can be overlooked, so we do recommend inspecting the return type of these operations: `getManager()`, `create...()`, `delete()`, `ban(...)`, `kick(...)` and similar when you use them so that you are not caught out.

--- a/docs/using-jda/troubleshooting.md
+++ b/docs/using-jda/troubleshooting.md
@@ -69,7 +69,7 @@ NDkyNzQ3NzY5MDM2MDEzNTc4.Xw2cUA.LLslVBE1tfFK20sGsNm-FVFYdsA
 
 Methods such as [`Message.getEmotes()`](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Message.html#getEmotes()) and [`Message.getEmotesBag()`](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Message.html#getEmotesBag()) only include custom emoji which have to be uploaded to a guild by a moderator. Unicode emoji such as 👍 are not included and require using a 3rd party library to be located in a string. You can use [emoji-java](https://github.com/vdurmont/emoji-java) to extract unicode emoji from a message.
 
-An example use-case including a code sample can be found in my answer to a related question on StackOverflow: https://stackoverflow.com/a/58353912/10630900
+An example use-case including a code sample can be found in my answer to a related question on [StackOverflow](https://stackoverflow.com/a/58353912/10630900)
 
 
 ## Event Handling and RestActions
@@ -108,15 +108,13 @@ If you *do* have a `queue()` then maybe your code doesn't even run? Try putting 
 
 There are many reasons why your event listener might not be executed but here are the most common issues:
 
-1. You are using a deprecated part of JDA? Such as `new JDABuilder(...)`
-    <br>Use the replacement that is documented. For example `createDefault(token)`
-1. You are using the wrong login token?
+1. You are using the wrong login token.
     <br>If the token is for another bot which doesn't have access to the desired guilds then the event listener code cannot run.
-1. Your bot is not actually in the guild?
+1. Your bot is not actually in the guild.
     <br>Make sure your bot is online and has access to the resource you are trying to interact with.
-1. You never registered your listener? 
+1. You never registered your listener.
     <br>Use `jda.addEventListener(new MyListener())` on either the `JDABuilder` or `JDA` instance
-1. You did not override the correct method?
+1. You did not override the correct method.
     <br>Use `@Override` and see if it fails. Your method has to use the correct name and parameter list defined in `ListenerAdapter`. [Read More](../introduction/events.md).
 1. You don't actually extend `EventListener` or `ListenerAdapter`.
     <br>Your class should **either** use `extends ListenerAdapter` or `implements EventListener`.

--- a/docs/using-jda/troubleshooting.md
+++ b/docs/using-jda/troubleshooting.md
@@ -110,19 +110,19 @@ There are many reasons why your event listener might not be executed but here ar
 
 1. You are using a deprecated or removed part of JDA, such as `new JDABuilder(...)`.
     <br>Use the replacement that is documented, for example `createDefault(token)`.
-2. You are using the wrong login token.
+1. You are using the wrong login token.
     <br>If the token is for another bot which doesn't have access to the desired guilds then the event listener code cannot run.
-3. Your bot is not actually in the guild.
+1. Your bot is not actually in the guild.
     <br>Make sure your bot is online and has access to the resource you are trying to interact with.
-4. You never registered your listener.
+1. You never registered your listener.
     <br>Use `jda.addEventListener(new MyListener())` on either the `JDABuilder` or `JDA` instance
-5. You did not override the correct method.
+1. You did not override the correct method.
     <br>Use `@Override` and see if it fails. Your method has to use the correct name and parameter list defined in `ListenerAdapter`. [Read More](../introduction/events.md).
-6. You don't actually extend `EventListener` or `ListenerAdapter`.
+1. You don't actually extend `EventListener` or `ListenerAdapter`.
     <br>Your class should **either** use `extends ListenerAdapter` or `implements EventListener`.
-7. You are missing a required [`GatewayIntent`](gateway-intents-and-member-cache-policy.md) for this event.
+1. You are missing a required [`GatewayIntent`](gateway-intents-and-member-cache-policy.md) for this event.
     <br>Make sure that you `enableIntents(...)` on the `JDABuilder` to allow the events to be received.
-8. The event has other requirements that might not be satisfied such as the cache not being enabled.
+1. The event has other requirements that might not be satisfied such as the cache not being enabled.
     <br>Please check the requirements on the event documentation.
 
 If none of the above apply to you then you might have an issue in your listener's code, at that point you should use a debugger.
@@ -280,9 +280,9 @@ There are many ways you can retrieve members dynamically: [Loading Members](gate
 This means you tried to use `GatewayIntent.GUILD_MEMBERS` or `GatewayIntent.GUILD_PRESENCES` without enabling it in your application dashboard. To use these privileged intents you first have to enable them.
 
 1. Open the [application dashboard](https://discord.com/developers/applications)
-2. Select your bot application
-3. Open the **Bot** tab
-4. Under the **Privileged Gateway Intents** section, enable either **SERVER MEMBERS INTENT** or **PRESENCE INTENT** depending on your needs.
+1. Select your bot application
+1. Open the **Bot** tab
+1. Under the **Privileged Gateway Intents** section, enable either **SERVER MEMBERS INTENT** or **PRESENCE INTENT** depending on your needs.
 
 If you use these intents you are limited to 100 guilds on your bot. To allow the bot to join more guilds while using this intent you have to [verify your bot](https://blog.discord.com/the-future-of-bots-on-discord-4e6e050ab52e). This will be available in your application dashboard when the bot joins at least 75 guilds.
 

--- a/docs/using-jda/troubleshooting.md
+++ b/docs/using-jda/troubleshooting.md
@@ -69,7 +69,7 @@ NDkyNzQ3NzY5MDM2MDEzNTc4.Xw2cUA.LLslVBE1tfFK20sGsNm-FVFYdsA
 
 Methods such as [`Message.getEmotes()`](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Message.html#getEmotes()) and [`Message.getEmotesBag()`](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Message.html#getEmotesBag()) only include custom emoji which have to be uploaded to a guild by a moderator. Unicode emoji such as 👍 are not included and require using a 3rd party library to be located in a string. You can use [emoji-java](https://github.com/vdurmont/emoji-java) to extract unicode emoji from a message.
 
-An example use-case including a code sample can be found in my answer to a related question on [StackOverflow](https://stackoverflow.com/a/58353912/10630900)
+An example use-case including a code sample can be found in [this answer to a related question on StackOverflow](https://stackoverflow.com/a/58353912/10630900)
 
 
 ## Event Handling and RestActions

--- a/docs/using-jda/troubleshooting.md
+++ b/docs/using-jda/troubleshooting.md
@@ -108,19 +108,21 @@ If you *do* have a `queue()` then maybe your code doesn't even run? Try putting 
 
 There are many reasons why your event listener might not be executed but here are the most common issues:
 
-1. You are using the wrong login token.
+1. You are using a deprecated or removed part of JDA, such as `new JDABuilder(...)`.
+    <br>Use the replacement that is documented, for example `createDefault(token)`.
+2. You are using the wrong login token.
     <br>If the token is for another bot which doesn't have access to the desired guilds then the event listener code cannot run.
-1. Your bot is not actually in the guild.
+3. Your bot is not actually in the guild.
     <br>Make sure your bot is online and has access to the resource you are trying to interact with.
-1. You never registered your listener.
+4. You never registered your listener.
     <br>Use `jda.addEventListener(new MyListener())` on either the `JDABuilder` or `JDA` instance
-1. You did not override the correct method.
+5. You did not override the correct method.
     <br>Use `@Override` and see if it fails. Your method has to use the correct name and parameter list defined in `ListenerAdapter`. [Read More](../introduction/events.md).
-1. You don't actually extend `EventListener` or `ListenerAdapter`.
+6. You don't actually extend `EventListener` or `ListenerAdapter`.
     <br>Your class should **either** use `extends ListenerAdapter` or `implements EventListener`.
-1. You are missing a required [`GatewayIntent`](gateway-intents-and-member-cache-policy.md) for this event.
+7. You are missing a required [`GatewayIntent`](gateway-intents-and-member-cache-policy.md) for this event.
     <br>Make sure that you `enableIntents(...)` on the `JDABuilder` to allow the events to be received.
-1. The event has other requirements that might not be satisfied such as the cache not being enabled.
+8. The event has other requirements that might not be satisfied such as the cache not being enabled.
     <br>Please check the requirements on the event documentation.
 
 If none of the above apply to you then you might have an issue in your listener's code, at that point you should use a debugger.

--- a/docs/using-jda/using-restaction.md
+++ b/docs/using-jda/using-restaction.md
@@ -38,10 +38,6 @@ Since **4.1.1** you can use a few RestAction operators to avoid callback hell wi
 Some operations return a special `RestAction` implementation called `AuditableRestAction`.
 <br>This extension allows to set a reason field for that action.
 
-These reasons are only available for accounts with __AccountType.BOT__ but will silently be ignored
-for any non-bot accounts.
-<br>However any account can use reasons on kick/ban with the special overloads provided that allow setting a reason.
-
 !!! example
     ```java
     public class ModerationUtil


### PR DESCRIPTION
Moves links that point to v4 to v5, and remove references to removed code, like `new JDABuilder(...)`

This is only for the using-jda directory, I will do more passes on other directories to bring it all up to date