### PR TITLE
Create GitHub Action for deploy previews

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,89 @@
+name: Pull request Deploy preview
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  deploy-preview:
+    name: Create Deploy-Preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/find-comment@v2
+        id: find-comment
+        name: Find Comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: gh-pages-deploy
+      - uses: peter-evans/create-or-update-comment@v2
+        id: comment
+        name: Create initial comment
+        with:
+          body: |-
+            ## Deploy Preview
+            
+            Building preview of Pull request. Please wait...
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.BOT }}
+          edit-mode: replace
+      - uses: actions/checkout@v3
+        name: Checkout Code
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: actions/setup-python@v4
+        name: Setup Python
+        with:
+          python-version: 3.7
+      - name: Install depencencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install -r requirements.txt
+      - name: Build docs
+        run: mkdocs build
+      - uses: peaceiris/actions-gh-pages@v3
+        name: Deploy pages
+        with:
+          personal_token: ${{ secrets.BOT }}
+          publish_dir: ./site
+          destination_dir: ./${{ github.repository }}/${{ github.event.pull_request.number }}
+          external_repository: gh-pages-deploy/Deploy-Previews
+          full_commit_message: 'Pushing deploy preview for Pull request ${{ github.event.pull_request.number }} from ${{ github.repository }}'
+      - name: Delay comment update by 30 seconds
+        run: sleep 30s
+        shell: bash
+      - uses: peter-evans/create-or-update-comment@v2
+        name: Update comment.
+        with:
+          body: |-
+            ## Deploy Preview
+            
+            Deploy-Preview complete!
+            
+            | Name   | Link                                                                                                               |
+            | ------ | ------------------------------------------------------------------------------------------------------------------ |
+            | Commit | ${{ github.event.pull_request.head.sha }}                                                                          |
+            | Link   | https://gh-pages-deploy.github.io/Deploy-Previews/${{ github.repository }}/${{ github.event.pull_request.number }} |
+            | Logs   | ${{ github.server_url }}/${{ github.repository }}/actions/run/${{ github.run_id }}                                 |
+          comment-id: ${{ steps.comment.outputs.comment-id }}
+          edit-mode: replace
+          token: ${{ secrets.BOT }}
+      - if: ${{ failure() }}
+        uses: peter-evans/create-or-update-comment@v2
+        name: Update comment.
+        with:
+          body: |-
+            ## Deploy Preview
+            
+            Deploy-Preview failed!
+            
+            | Name   | Link                                                                                               |
+            | ------ | -------------------------------------------------------------------------------------------------- |
+            | Commit | ${{ github.event.pull_request.head.sha }}                                                          |
+            | Logs   | ${{ github.server_url }}/${{ github.repository }}/actions/run/${{ github.run_id }}                 |
+          comment-id: ${{ steps.comment.outputs.comment-id }}
+          edit-mode: replace
+          token: ${{ secrets.BOT }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material==8.3.9


### PR DESCRIPTION
Adds a Workflow that automatically builds previews of Pull requests using a dedicated Account (@gh-pages-deploy) I made a while ago for this exact purpose.

This has been discussed in [splash page, take 2](https://discord.com/channels/125227483518861312/995427583216861204) with DV8 and he showed a general interest in this.

This PR also adds a `requirements.txt` as the action uses it to more easily obtain the required software such as Material for MkDocs.

Closes #18 

#### How it works
The action does the following things:

- Gets the PRs content
- Builds pages using `mkdocs build`
- Push pages to https://github.com/gh-pages-deploy/Deploy-Previews on the `gh-pages` branch under a dedicated directory (In this case `DV8FromTheWorld/JDA-Website/<pr.number>`)
- Replies to PR with a comment containing the result (URL of the final deploy)

This process is repeated whenever an update is pushed to a PR. The comment will be edited in this case.

Example result: https://github.com/Andre601/blog/pull/79#issuecomment-1174106662

#### Why this setup?
I'm well aware that services such as netlify or Vercel exist. But they will often require you to add extra bots to your repository, and in the case of netlify also need a lot of configuration to get rid of useless stuff (Status checks).

Not to mention are they not *just* for previews, but also always build production versions of the site, which is useless.
Finally, are they often also limited to X amount of build minutes. Those limits are often quite generous, but still.

This setup allows you to use GitHub Pages to have previews (and only previews) for Pull requests without the need to add external bots or grant external sites access to your account.
It comes at the cost of a more complicated setup tho with the requirement of a PAT.

Hopefully, GitHub will soon add PR deploy previews to their services... (They mentioned such a thing to be planned).

#### Missing required steps

- [ ] Adding the account's PAT as Secret with name `BOT` to the Repository. DV8 already has said PAT and will add it once he has time.
- [ ] (Probably) grant write access for the Account? I'm not to sure about what privileges the account needs to pull changes, build them and push them to an external repository.