### PR TITLE
Make deploy preview concurrency safe.

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -20,6 +20,10 @@ on:
       - 'mkdocs.yml'
       - 'requirements.txt'
 
+concurrency:
+  group: "deploy-preview"
+  cancel-in-progress: true
+
 jobs:
   deploy-preview:
     name: Create Deploy-Preview


### PR DESCRIPTION
Minor fix to the deploy preview action to make sure that only one action instance is running, as there could be the rare but possible chance of two PRs triggering it close to each other, resulting in errors.

I'm not sure if `cancel-in-progress: true` is a good idea here, as it could cause one PR to not receive a deploy preview if it happens to be the one that gets the run cancelled.
If I understand the concurrency option right will actions simply get delayed/queued up when one of the same group is running.

The main issue I see here is, that there isn't an easy way to delay actions for different PRs while cancelling actions for the same PR, so it's more or less a global thing here...
If anyone has a good idea, let me know (I'll also ask in the GH Community discussion for help)