### PR TITLE
Add v5 migration page

### DIFF
--- a/docs/assets/stylesheets/tasklists.css
+++ b/docs/assets/stylesheets/tasklists.css
@@ -1,5 +1,3 @@
-{% extends "main.html" %}
-<style>
 :root {
     --md-custom-tasklist-icon--unchecked: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m330 768 150-150 150 150 42-42-150-150 150-150-42-42-150 150-150-150-42 42 150 150-150 150 42 42Zm150 208q-82 0-155-31.5t-127.5-86Q143 804 111.5 731T80 576q0-83 31.5-156t86-127Q252 239 325 207.5T480 176q83 0 156 31.5T763 293q54 54 85.5 127T880 576q0 82-31.5 155T763 858.5q-54 54.5-127 86T480 976Z"/></svg>');
     --md-custom-tasklist-icon--checked: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m346 996-76-130-151-31 17-147-96-112 96-111-17-147 151-31 76-131 134 62 134-62 77 131 150 31-17 147 96 111-96 112 17 147-150 31-77 130-134-62-134 62Zm91-287 227-225-45-41-182 180-95-99-46 45 141 140Z"/></svg>');
@@ -20,4 +18,3 @@
 .tabbed-set label.task-list-control {
     margin: 0 0em;
 }
-</style>

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -1,6 +1,6 @@
 # Migration Guide 4.X to 5.X
 
-This version includes several breaking changes and improvements.
+This version utilizes Discord API v10, and includes several breaking changes and improvements.
 
 ## Extensions That Support 5.X
 
@@ -12,6 +12,18 @@ The ones that are not checked do not support it yet. You should check that every
 - [x] [jda-nas](https://github.com/sedmelluq/jda-nas)
     - [x] [udpqueue.rs](https://github.com/MinnDevelopment/udpqueue.rs) (for minimal Rust bindings)
 - [ ] [JDA-Utilities](https://github.com/JDA-Applications/JDA-Utilities)
+
+## Introduction of Message Content Privileged Intent
+
+As part of upgrading to API v10, accessing the following user-generated content in messages now requires the Message Content privileged intent (`GatewayIntent.MESSAGE_CONTENT`):
+
+- Text content (`Message#getContentRaw`, `Message#getContentDisplay`, `Message#getContentStripped`)
+- Embeds (`Message#getEmbeds`)
+- Attachments (`Message#getAttachments`)
+- Message Components (`Message#getActionRows`, `Message#getButtons`)
+- Custom Emoji Mentions (`Message#getMentions()#getCustomEmojis()`)
+
+You must enable this intent in your `JDABuilder` **AND** in the Discord Developer Portal for your app if you utilize any of the above methods.
 
 ## Channel Rework
 

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -343,3 +343,41 @@ commands.addCommands(
 ```
 
 You can also limit it to administrators with `DefaultMemberPermissions.DISABLED`.
+
+## UserSnowflake Type
+
+We have started to cut down on overloads which accept 3 different inputs to specify a user. Previously methods like `Guild#ban` had many overloads to account for different types such as `String`/`long`/`User`/`Member`. We removed all of these in favor of a single `UserSnowflake` input, which can be constructed with `User.fromId(long/String)`. Both `User` and `Member` also implement this interface. This is a far more elegant handling and reduces the number of overloads in various parts of the API drastically.
+
+This applies to the following methods:
+
+- `Guild#ban(long/String)`, `Guild#ban(long/String, int)`, `Guild#ban(long/String, int, String)`<br>
+    Now just `Guild#ban(UserSnowflake, int, TimeUnit)`
+- `Guild#kick(long/String)`, `Guild#kick(long/String, String)`<br>
+    Now just `Guild#kick(UserSnowflake)`
+- `Guild#unban(long/String)` is now `Guild#unban(UserSnowflake)`
+- `Guild#retrieveBanById(long/String)` is now `Guild#retrieveBan(UserSnowflake)`
+- `Guild#addMember(String, long/String)` is now `Guild#addMember(UserSnowflake)`
+- `Guild#timeoutForById(long/String, Duration)` is now `Guild#timeoutFor(UserSnowflake, Duration)`
+- `Guild#timeoutUntilById(long/String, TemporalAccessor)` is now `Guild#timeoutUntil(UserSnowflake, TemporalAccessor)`
+- `Guild#removeTimeoutById(long/String)` is now `Guild#removeTimeout(UserSnowflake)`
+- `Guild#addRoleToMember(long/String, Role)` is now `Guild#addRoleToMember(UserSnowflake)`
+- `Guild#removeRoleFromMember(long/String, Role)` is now `Guild#removeRoleFromMember(UserSnowflake)`
+- `AuditLogPaginationAction#user(long/String)` is now `AuditLogPaginationAction#user(UserSnowflake)`
+
+### Ban Precision
+
+You can now specify the age of messages to delete in seconds precision. To adjust your code simply add `TimeUnit.DAYS` to the end and move the ban reason into the `reason(...)` method:
+
+**Old:**
+
+```java
+guild.ban(user, 7, "Naughty words").queue()
+```
+
+**New:**
+
+```java
+guild.ban(user, 7, TimeUnit.DAYS).reason("Naughty words").queue()
+```
+
+Kick reasons have also been moved into the `reason(...)` method, for example `guild.kick(user, reason)` turns into `guild.kick(user).reason(reason)`.

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -11,7 +11,7 @@ Before continuing, we should mention that JDA versions are now distributed via [
 Replace `$latest` with this version ![Maven Version](https://img.shields.io/maven-central/v/net.dv8tion/JDA?color=blue)
 
 ```gradle
-repositores {
+repositories {
     mavenCentral()
 }
 
@@ -164,7 +164,7 @@ With context-specific events being removed (such as `GuildMessageReceivedEvent`)
 
 ### Session Events
 
-All events that update the gateway session of a bot now extend a common [`GenericSessionEvent`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/events/session/GenericSessionEvent.html). Such events are located within [the `net.dv8tion.jda.api.events.session` pakage](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/events/session/package-summary.html). This also includes `ReadyEvent` and `ShutdownEvent`.
+All events that update the gateway session of a bot now extend a common [`GenericSessionEvent`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/events/session/GenericSessionEvent.html). Such events are located within [the `net.dv8tion.jda.api.events.session` package](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/events/session/package-summary.html). This also includes `ReadyEvent` and `ShutdownEvent`.
 
 Some events relating to sessions have been renamed:
 
@@ -191,7 +191,7 @@ The following intents have been renamed to align with the API name convention:
 
 ### Chunking and Caching
 
-If you used `ChunkingFilter.ALL` in the past, JDA would atomatically also cache all those members it chunked. However, this is not a very flexible rule and we changed this behavior. Instead, the `MemberCachePolicy` will control which members to keep cached after chunking.
+If you used `ChunkingFilter.ALL` in the past, JDA would automatically also cache all those members it chunked. However, this is not a very flexible rule and we changed this behavior. Instead, the `MemberCachePolicy` will control which members to keep cached after chunking.
 
 ## Sticker and Emoji Rework
 
@@ -211,7 +211,7 @@ In old versions we always made a distinction between **Emote** and **Emoji** to 
 
 All methods/enums/types using `emote` have also been adjusted to say `emoji`, for example `Guild#retrieveEmotes` is now `Guild#retrieveEmojis` and `CacheFlag.EMOTE` is now `CacheFlag.EMOJI`.
 
-This new design also had the goal to unify all usages of emoji in the API, allowing you to use them for anything that makes use of emoji. For instance, previously there was a distinction between reaction emoji (`MessageReaction.ReactionEmote`) and buttom emoji (`Emoji`), which now both use the same `Emoji` type:
+This new design also had the goal to unify all usages of emoji in the API, allowing you to use them for anything that makes use of emoji. For instance, previously there was a distinction between reaction emoji (`MessageReaction.ReactionEmote`) and button emoji (`Emoji`), which now both use the same `Emoji` type:
 
 ```java
 public void onMessageReactionAdd(MessageReactionAddEvent event) {

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -1,0 +1,15 @@
+# Migration Guide 4.X to 5.X
+
+This version includes several breaking changes and improvements.
+
+## Extensions That Support 5.X
+
+Here is a list of known extensions that support 5.X.
+The ones that are not checked do not support it yet. You should check that everything used in your project supports 5.X before starting migration.
+
+- [ ] [jda-reactor](https://github.com/MinnDevelopment/jda-reactor)
+- [ ] [LavaPlayer](https://github.com/sedmelluq/lavaplayer)
+- [ ] [jda-nas](https://github.com/sedmelluq/jda-nas)
+- [ ] [JDA-Utilities](https://github.com/JDA-Applications/JDA-Utilities)
+- [ ] [Lavalink Client](https://github.com/FredBoat/Lavalink-Client)
+- [ ] [JDAction](https://github.com/sedmelluq/jdaction)

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -7,10 +7,10 @@ This version includes several breaking changes and improvements.
 Here is a list of known extensions that support 5.X.
 The ones that are not checked do not support it yet. You should check that everything used in your project supports 5.X before starting migration.
 
-- [ ] [jda-reactor](https://github.com/MinnDevelopment/jda-reactor)
-- [ ] [LavaPlayer](https://github.com/sedmelluq/lavaplayer)
-- [ ] [jda-nas](https://github.com/sedmelluq/jda-nas)
-    - [ ] [udpqueue.rs](https://github.com/MinnDevelopment/udpqueue.rs) (for minimal Rust bindings)
+- [x] [jda-reactor](https://github.com/MinnDevelopment/jda-reactor)
+- [x] [LavaPlayer](https://github.com/sedmelluq/lavaplayer)
+- [x] [jda-nas](https://github.com/sedmelluq/jda-nas)
+    - [x] [udpqueue.rs](https://github.com/MinnDevelopment/udpqueue.rs) (for minimal Rust bindings)
 - [ ] [JDA-Utilities](https://github.com/JDA-Applications/JDA-Utilities)
 
 ## Channel Rework

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -235,16 +235,16 @@ Due to changes in the Discord API v10, you can no longer add files to messages w
 ```java
 // Here "message" is an instance of the Message interface
 
- // Take the first attachment of the message, all others will be removed
- AttachedFile attachment = message.getAttachments().get(0);
+// Take the first attachment of the message, all others will be removed
+AttachedFile attachment = message.getAttachments().get(0);
 
- // The name here will be "cat.png" to discord, what the file is called on your computer is irrelevant and only used to read the data of the image.
- FileUpload file = FileUpload.fromData(new File("mycat-final-copy.png"), "cat.png"); // Opens the file called "cat.png" and provides the data used for sending
+// The name here will be "cat.png" to discord, what the file is called on your computer is irrelevant and only used to read the data of the image.
+FileUpload file = FileUpload.fromData(new File("mycat-final-copy.png"), "cat.png"); // Opens the file called "cat.png" and provides the data used for sending
 
- // Edit request to keep the first attachment, and add one more file to the message
- message.editMessage("New content")
-        .setAttachments(attachment, file)
-        .queue();
+// Edit request to keep the first attachment, and add one more file to the message
+message.editMessage("New content")
+       .setAttachments(attachment, file)
+       .queue();
 ```
 
 

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -100,21 +100,21 @@ There are several changes related to events.
 
 All message event types for guild messages have been removed. Examples of these are:
 
-- Generic<Context>MessageEvent (ex: GenericGuildMessageEvent)
-- <Context>MessageReceivedEvent (ex: GuildMessageReceivedEvent)
-- <Context>MessageUpdateEvent (ex: GuildMessageUpdateEvent)
-- <Context>MessageDeleteEvent (ex: GuildMessageDeleteEvent)
-- <Context>MessageEmbedEvent (ex: GuildMessageEmbedEvent)
-- <Context>MessageReaction<X>Event (ex: GuildMessageReactionAddEvent)
+- `Generic<Context>MessageEvent` (ex: `GenericGuildMessageEvent`)
+- `<Context>MessageReceivedEvent` (ex: `GuildMessageReceivedEvent`)
+- `<Context>MessageUpdateEvent` (ex: `GuildMessageUpdateEvent`)
+- `<Context>MessageDeleteEvent` (ex: `GuildMessageDeleteEvent`)
+- `<Context>MessageEmbedEvent` (ex: `GuildMessageEmbedEvent`)
+- `<Context>MessageReaction<X>Event` (ex: `GuildMessageReactionAddEvent`)
 - etc
 
 Instead, you should use the unified versions of these events:
 
-- GenericMessageEvent
-- MessageReceivedEvent
-- MessageUpdatedEvent
-- MessageDeletedEvent
-- MessageReaction<X>Event (ex: MessageReactionAddEvent)
+- `GenericMessageEvent`
+- `MessageReceivedEvent`
+- `MessageUpdatedEvent`
+- `MessageDeletedEvent`
+- `MessageReaction<X>Event` (ex: `MessageReactionAddEvent`)
 - etc
 
 You can check if a message is from a `Guild` by using `Message#isFromGuild()`.

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -2,6 +2,36 @@
 
 This version utilizes Discord API v10, and includes several breaking changes and improvements.
 
+## Dependency Installation
+
+Before continuing, we should mention that JDA versions are now distributed via [Maven Central](https://mvnrepository.com/artifact/net.dv8tion/JDA/5.0.0-beta.5). You can remove the old `m2.dv8tion.net` resolver from your build files.
+
+### Gradle
+
+Replace `$latest` with this version ![Maven Version](https://img.shields.io/maven-central/v/net.dv8tion/JDA?color=blue)
+
+```gradle
+repositores {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("net.dv8tion:JDA:$latest")
+}
+```
+
+### Maven
+
+Replace `$latest` with this version ![Maven Version](https://img.shields.io/maven-central/v/net.dv8tion/JDA?color=blue)
+
+```xml
+<dependency>
+    <groupId>net.dv8tion</groupId>
+    <artifactId>JDA</artifactId>
+    <version>$latest</version>
+</dependency>
+```
+
 ## Additional Resources
 
 This migration guide does not include every single detail and does not focus on any new features available in JDA 5, such as [ThreadChannels](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/concrete/ThreadChannel.html). Here are some useful resources to learn more if you are curious about all the new things we added:
@@ -59,7 +89,7 @@ A lot of classes in JDA used to have specific getters for each channel type, for
 
 `GuildChannel` now implements `getGuild` and `getManager` *only*. It's meant to serve as a generic type to hold channels from guilds.
 
-Specific channel attributes, such as slowmode and permissions, have been split into several interfaces. These interfaces can be found in [the `net.dv8tion.jda.api.entities.channel.attribute` package](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/attribute/package-summary.html). Each interface in this package extends `GuildChannel`.
+Specific channel attributes, such as slowmode and permissions, have been split into several interfaces. These interfaces can be found in [the `net.dv8tion.jda.api.entities.channel.attribute` package](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/attribute/package-summary.html). Each interface in this package extends `GuildChannel`.
 
 ### Permission Access Changes
 
@@ -71,11 +101,11 @@ Of course, if you have a channel type that already supports `IPermissionContaine
 
 In JDA v4, `GuildChannel#getManager` returned a `ChannelManager` that gave every possible setter for every channel type. This caused for `UnsupportedOperationException` or `IllegalStateException` to be thrown in some cases, such as calling `setBitrate` on a `TextChannel`.
 
-JDA v5 provides type-trimmed channel managers, which provide only the setters that we know *for sure* can work on the given channel. Each of these managers can be found in [the `net.dv8tion.jda.api.managers.channel` package](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/managers/channel/package-summary.html). These all follow the same implement/extension hierarchy as the channels do and map 1:1.
+JDA v5 provides type-trimmed channel managers, which provide only the setters that we know *for sure* can work on the given channel. Each of these managers can be found in [the `net.dv8tion.jda.api.managers.channel` package](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/managers/channel/package-summary.html). These all follow the same implement/extension hierarchy as the channels do and map 1:1.
 
 ### Independant Stage Channel and News Channel Entities
 
-[`StageChannel`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/concrete/StageChannel.html) and [`NewsChannel`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/concrete/NewsChannel.html) were previously variants of `VoiceChannel` and `TextChannel`. These are now their own independant entities. This comes with a number of changes:
+[`StageChannel`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/concrete/StageChannel.html) and [`NewsChannel`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/concrete/NewsChannel.html) were previously variants of `VoiceChannel` and `TextChannel`. These are now their own independant entities. This comes with a number of changes:
 
 - `ChannelAction#setNews` has been removed in favor of `ChannelAction.setType`
 - `ChannelManager#getType` was removed in favor of `ChannelManager#getChannel()#getType`
@@ -134,7 +164,7 @@ With context-specific events being removed (such as `GuildMessageReceivedEvent`)
 
 ### Session Events
 
-All events that update the gateway session of a bot now extend a common [`GenericSessionEvent`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/events/session/GenericSessionEvent.html). Such events are located within [the `net.dv8tion.jda.api.events.session` pakage](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/events/session/package-summary.html). This also includes `ReadyEvent` and `ShutdownEvent`.
+All events that update the gateway session of a bot now extend a common [`GenericSessionEvent`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/events/session/GenericSessionEvent.html). Such events are located within [the `net.dv8tion.jda.api.events.session` pakage](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/events/session/package-summary.html). This also includes `ReadyEvent` and `ShutdownEvent`.
 
 Some events relating to sessions have been renamed:
 
@@ -144,7 +174,7 @@ Some events relating to sessions have been renamed:
 
 ### Voice State Events
 
-`GuildVoiceJoinEvent` and `GuildVoiceLeaveEvent` have both been removed in favor of the unified [`GuildVoiceUpdateEvent`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/events/guild/voice/GuildVoiceUpdateEvent.html).
+`GuildVoiceJoinEvent` and `GuildVoiceLeaveEvent` have both been removed in favor of the unified [`GuildVoiceUpdateEvent`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/events/guild/voice/GuildVoiceUpdateEvent.html).
 
 As an example, to detect when a user leaves a voice channel, you can use `GuildVoiceUpdateEvent#getChannelLeft`. This method will return the channel that the user left, or `null` if the user joined a channel instead.
 

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -1,7 +1,3 @@
----
-template: migration-v5.html
----
-
 # Migration Guide 4.X to 5.X
 
 This version utilizes Discord API v10, and includes several breaking changes and improvements.

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -134,3 +134,18 @@ Some events relating to sessions have been renamed:
 `GuildVoiceJoinEvent` and `GuildVoiceLeaveEvent` have both been removed in favor of the unified [`GuildVoiceUpdateEvent`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/events/guild/voice/GuildVoiceUpdateEvent.html).
 
 As an example, to detect when a user leaves a voice channel, you can use `GuildVoiceUpdateEvent#getChannelLeft`. This method will return the channel that the user left, or `null` if the user joined a channel instead.
+
+## Intent and Member Cache Changes
+
+A few changes to intents and member caching were also made to improve the user experience.
+
+### Renamed Intents
+
+The following intents have been renamed to align with the API name convention:
+
+- `GatewayIntent.GUILD_BANS` renamed to `GatewayIntent.GUILD_MODERATION`
+- `GatewayIntent.GUILD_EMOJIS` renamed to `GatewayIntent.GUILD_EMOJIS_AND_STICKERS`
+
+### Chunking and Caching
+
+If you used `ChunkingFilter.ALL` in the past, JDA would atomatically also cache all those members it chunked. However, this is not a very flexible rule and we changed this behavior. Instead, the `MemberCachePolicy` will control which members to keep cached after chunking.

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -10,4 +10,5 @@ The ones that are not checked do not support it yet. You should check that every
 - [ ] [jda-reactor](https://github.com/MinnDevelopment/jda-reactor)
 - [ ] [LavaPlayer](https://github.com/sedmelluq/lavaplayer)
 - [ ] [jda-nas](https://github.com/sedmelluq/jda-nas)
+    - [ ] [udpqueue.rs](https://github.com/MinnDevelopment/udpqueue.rs) (for minimal Rust bindings)
 - [ ] [JDA-Utilities](https://github.com/JDA-Applications/JDA-Utilities)

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -272,6 +272,22 @@ List<String> contents = SplitUtil.split(
 List<MessageCreateData> messages = contents.stream().map(MessageCreateData::fromContent).toList();
 ```
 
+## Mentions Rework
+
+We made the handling of mentions consistent across both messages and interactions. You can now access mentions inside string options of slash commands through `OptionMapping#getMentions`. The old methods on `Message` have also been moved to a new `Mentions` interface, accessible via `Message#getMentions`.
+
+- `Message#getMentionedUsers` moved to `Mentions#getUsers`
+- `Message#getMentionedMembers` moved to `Mentions#getMembers`
+- `Message#getMentionedChannels` moved to `Mentions#getChannels`
+- `Message#getEmotes` moved to `Mentions#getCustomEmojis`
+- `Message#getMentions(MentionType...)` moved to `Mentions#getMentions(MentionType...)`
+- `Message#isMentioned` moved to `Mentions#isMentioned`
+- `Message#getMentionedMembers(Guild)` has been removed with no replacement
+- `Message#mentionsEveryone` moved to `Mentions#mentionsEveryone`
+- Analogously for all bag getters.
+
+Additionally, the return type of `Mentions#getChannels` has been adjusted to return `List<GuildChannel>` since all channel types can now be mentioned. You can use `Mentions#getChannels(Class)` to limit it to specific types, for example `List<TextChannel> channels = mentions.getChannels(TextChannel.class)`.
+
 ## Interaction Rework
 
 To properly handle **Context Menu** and **Auto-complete** interactions, we reworked some of the interaction types. This includes numerous breaking changes to naming conventions and package layouts.

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -237,7 +237,7 @@ In JDA 5 we are separating the handling of message sending and editing, while al
 - `MessageEditBuilder`
 - `MessageEditAction`
 
-This change should only affect few people who made use of `MessageBuilder` in the past. You need to update your code to either the edit or create builders. If you don't know whether the resulting operation is an edit or send request, you can simply always use `MessageEditBuilder` and then use `MessageCreateData.fromEdit(MessageEditData)` to convert it at call-site. You can also use similar factory methods to create a sendable message from the `Message` interface (`MessageCreateData.fromMessage(message)`).
+This change should only affect people who made use of `MessageBuilder` in the past. You need to update your code to either the edit or create builders. If you don't know whether the resulting operation is an edit or send request, you can simply always use `MessageEditBuilder` and then use `MessageCreateData.fromEdit(MessageEditData)` to convert it at call-site. You can also use similar factory methods to create a sendable message from the `Message` interface (`MessageCreateData.fromMessage(message)`).
 
 Previously, edit requests had a method called `override(boolean)` to *replace* the entire message. This was used to remove content or embeds from a message. You can now simply use `setEmbeds(emptyList())` or `setContent("")` to remove specific parts of the message, or use `setReplace(true)` to achieve the same functionality of replacing everything.
 

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -271,3 +271,38 @@ List<String> contents = SplitUtil.split(
 // Convert to instance of MessageCreateData (optional, you can just send strings directly!)
 List<MessageCreateData> messages = contents.stream().map(MessageCreateData::fromContent).toList();
 ```
+
+## Interaction Rework
+
+To properly handle **Context Menu** and **Auto-complete** interactions, we reworked some of the interaction types. This includes numerous breaking changes to naming conventions and package layouts.
+
+### Naming Changes
+
+- `SlashCommandEvent` renamed to `SlashCommandInteractionEvent`
+- `ButtonClickEvent` renamed to `ButtonInteractionEvent`
+- `SelectionMenu` renamed to `StringSelectMenu`
+- `SelectionMenuEvent` renamed to `StringSelectEvent`
+- `Component` renamed to `ActionComponent` and `ItemComponent` (abstraction for things like `Button`)
+- `ComponentLayout` renamed to `LayoutComponent` (abstraction for things like `ActionRow`)
+- Introduced **new** `Component` interface to abstract both layouts and items.
+- `MessageType.APPLICATION_COMMAND` renamed to `MessageType.SLASH_COMMAND` (we now also have `MessageType.CONTEXT_COMMAND`)
+- `InteractionType.SLASH_COMMAND` renamed to `InteractionType.COMMAND` (we now also have `InteractionType.COMMAND_AUTOCOMPLETE`)
+
+### Creating and Handling Commands
+
+With the introduction of **Context Menu Commands**, we changed how commands are created. Instead of `new CommandData(...)`, you now create a slash command using the factory method `Commands.slash(...)`, which returns a `SlashCommandData` instance that has the familiar methods. You can now also use `Commands.user(...)` and `Commands.message(...)` to create new context menu commands which appear in the right-click menu option named **Apps** in the Discord Client.
+
+Handling commands only changed slightly with regards to the way you reply. Previously, all `Interaction` types had a `reply(...)` or `deferReply(...)` method. This has been changed due to new interaction types like **AutoCompleteInteraction** and **ModalInteraction**. Now, each concrete interaction type implements specific **callback** interfaces such as:
+
+- `IReplyCallback`<br>
+    Which supports direct message replies and deferred message replies via `reply(String)` and `deferReply()`
+- `IMessageEditCallback`<br>
+    Which supports direct message edits and deferred message edits (or no-operation) via `editMessage(String)` and `deferEdit()`
+- `IModalCallback`<br>
+    Which supports choice suggestions for auto-complete interactions via `replyChoices(Command.Choice...)`
+- `IAutoCompleteCallback`<br>
+    Which supports replying using a Modal via `replyModal(Modal)`
+
+If you relied on the abstract `Interaction` type to provide any of these methods, you will have to adjust your code to use these new interfaces instead.
+
+You can find more explanations and examples in the dedicated [Interactions Wiki Page](/using-jda/interactions/).

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -103,9 +103,9 @@ In JDA v4, `GuildChannel#getManager` returned a `ChannelManager` that gave every
 
 JDA v5 provides type-trimmed channel managers, which provide only the setters that we know *for sure* can work on the given channel. Each of these managers can be found in [the `net.dv8tion.jda.api.managers.channel` package](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/managers/channel/package-summary.html). These all follow the same implement/extension hierarchy as the channels do and map 1:1.
 
-### Independant Stage Channel and News Channel Entities
+### Independent Stage Channel and News Channel Entities
 
-[`StageChannel`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/concrete/StageChannel.html) and [`NewsChannel`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/concrete/NewsChannel.html) were previously variants of `VoiceChannel` and `TextChannel`. These are now their own independant entities. This comes with a number of changes:
+[`StageChannel`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/concrete/StageChannel.html) and [`NewsChannel`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/concrete/NewsChannel.html) were previously variants of `VoiceChannel` and `TextChannel`. These are now their own independent entities. This comes with a number of changes:
 
 - `ChannelAction#setNews` is replaced by `ChannelAction.setType`
 - `ChannelManager#getType` is replaced by `ChannelManager#getChannel()#getType`
@@ -418,3 +418,25 @@ guild.ban(user, 7, TimeUnit.DAYS).reason("Naughty words").queue()
 ```
 
 Kick reasons have also been moved into the `reason(...)` method, for example `guild.kick(user, reason)` turns into `guild.kick(user).reason(reason)`.
+
+## Managers are no longer persistent
+
+All getters for managers in JDA used to be lazy-idempotent, such that calling `getManager()` twice would return the same instance. This has been removed to reduce memory usage an complexity. If you previously relied on this behavior, you will need to adjust your code.
+
+**Old:**
+
+```java
+channel.getManager().setName("new-name");
+channel.getManager().setTitle("here is my title");
+channel.getManager().queue();
+```
+
+**New:**
+
+```java
+// Use method chaining or declare a variable to re-use the manager
+channel.getManager()
+       .setName("new-name")
+       .setTitle("here is my title")
+       .queue();
+```

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -11,5 +11,3 @@ The ones that are not checked do not support it yet. You should check that every
 - [ ] [LavaPlayer](https://github.com/sedmelluq/lavaplayer)
 - [ ] [jda-nas](https://github.com/sedmelluq/jda-nas)
 - [ ] [JDA-Utilities](https://github.com/JDA-Applications/JDA-Utilities)
-- [ ] [Lavalink Client](https://github.com/FredBoat/Lavalink-Client)
-- [ ] [JDAction](https://github.com/sedmelluq/jdaction)

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -23,17 +23,30 @@ As part of upgrading to API v10, accessing the following user-generated content 
 - Message Components (`Message#getActionRows`, `Message#getButtons`)
 - Custom Emoji Mentions (`Message#getMentions()#getCustomEmojis()`)
 
-You must enable this intent in your `JDABuilder` **AND** in the Discord Developer Portal for your app if you utilize any of the above methods.
+You must enable this intent in your `JDABuilder` **AND** in the Discord Developer Portal for your app if you utilize any of the above methods. For more information on intents, read the [dedicated wiki page](/using-jda/gateway-intents-and-member-cache-policy).
 
 ## Channel Rework
 
-There are several breaking changes to `GuildChannel` and `ChannelManager`
+There are several breaking changes to `GuildChannel` and `ChannelManager`. Firstly, the packages of most channel interfaces have changed. What was previously simply found in `net.dv8tion.jda.api.entities` is now split over the following packages:
+
+- `net.dv8tion.jda.api.entities.channel`<br>
+    Top level channel enums and the new `Channel` type interface.
+- `net.dv8tion.jda.api.entities.channel.attribute`<br>
+    Interfaces dedicated to specific fields, such as slowmode or permissions. This also has some interfaces for *concepts*, such as copying or categorizing.
+- `net.dv8tion.jda.api.entities.channel.concrete`<br>
+    The bottom level interfaces for exact concrete types, such as `VoiceChannel` and `TextChannel`.
+- `net.dv8tion.jda.api.entities.channel.forums`<br>
+    Types related to `ForumChannel`, such as tags.
+- `net.dv8tion.jda.api.entities.channel.middleman`<br>
+    Abstractions that apply to multiple concrete types, such as `MessageChannel` which covers all message related methods.
+- `net.dv8tion.jda.api.entities.channel.unions`<br>
+    Interfaces used for return values, allowing for downcasting into specific types. They also provided shared features of the specific interface they extend.
 
 ### New Channel Attribute Interfaces
 
 `GuildChannel` now implements `getGuild` and `getManager` *only*. It's meant to serve as a generic type to hold channels from guilds.
 
-Specific channel attributes, such as slow mode, permissions, etc have been split into several interfaces. These interfaces can be found in [the `net.dv8tion.jda.api.entities.channel.attribute` package](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/attribute/package-summary.html). Each interface in this package extends `GuildChannel`.
+Specific channel attributes, such as slowmode and permissions, have been split into several interfaces. These interfaces can be found in [the `net.dv8tion.jda.api.entities.channel.attribute` package](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/attribute/package-summary.html). Each interface in this package extends `GuildChannel`.
 
 ### Permission Access Changes
 

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -33,3 +33,14 @@ Specific channel attributes, such as slow mode, permissions, etc have been split
 - `TextChannel#crosspostMessage` was removed in favor of `NewsChannel#crosspostMessage`
 - `TextChannel#follow` has been removed in favor of `NewsChannel#follow`
 - `TextChannel#isNews` has been removed
+
+## Permission Changes
+
+A number of permissions have been renamed, with one permission being removed entirely.
+
+- `Permission.MANAGE_EMOTES` was renamed to `Permission.MANAGE_EMOTES_AND_STICKERS`
+- `Permission.MESSAGE_READ` has been removed in favor of `Permission.VIEW_CHANNEL`
+- `Permission.MESSAGE_WRITE` was renamed to `Permission.MESSAGE_SEND`
+- `Permission.USE_SLASH_COMMANDS` was renamed to `Permission.USE_APPLICATION_COMMANDS`
+- `Permission.USE_PUBLIC_THREADS` was renamed to `Permission.CREATE_PUBLIC_THREADS`
+- `Permission.USE_PRIVATE_THREADS` was renamed to `Permission.CREATE_PRIVATE_THREADS`

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -79,7 +79,7 @@ There are several breaking changes to `GuildChannel` and `ChannelManager`. First
 
 ### Channel Return Types
 
-A lot of classes in JDA used to have specific getters for each channel type, for instance messages had `getTextChannel()` and `getPrivateChannel()`. The goal was to allow easy conversion to concrete types that have more functionality than their abstract counterpart (such as `MessageChannel`). We've introduced new **Channel Union** interfaces to deal with this problem in a more elegant way. Instead of using `foo.getTextChannel()`, you now use `foo.getChannel().asTextChannel()`. The `getChannel()` method now often returns a specific **Union** type such as `MessageChannelUnion`, which doubles as the abstract implementation for `MessageChannel` (allows to send messages) and also downcasting via various `asX()` methods.
+Many classes in JDA had specific getters for each channel type. For example, messages had `getTextChannel()` and `getPrivateChannel()`. The goal was to allow easy conversion to concrete types that have more functionality than their abstract counterpart (such as `MessageChannel`). In JDA v5, we've introduced new **Channel Union** interfaces to deal with this problem in a more elegant way. Instead of using `foo.getTextChannel()`, you now use `foo.getChannel().asTextChannel()`. The `getChannel()` method now often returns a specific **Union** type such as `MessageChannelUnion`, which doubles as the abstract implementation for `MessageChannel` (allows to send messages) and also downcasting via various `asX()` methods.
 
 ### New Channel Attribute Interfaces
 
@@ -89,7 +89,7 @@ Specific channel attributes, such as slowmode and permissions, have been split i
 
 ### Permission Access Changes
 
-With JDA v5 introducing a more butchered down `GuildChannel` interface, `GuildChannel#getPermissionContainer() : IPermissionContainer` has been introduced to make accessing permissions easier. This allows for users to confidently access the entity that dictates the permissions for a given channel without having to check whether the channel actually supports permissions, such as in the case of threads.
+With JDA v5 we reduced the capabilities of the `GuildChannel` interface. The method `GuildChannel#getPermissionContainer` has been introduced to make accessing permissions easier. This allows for users to confidently access the entity that dictates the permissions for a given channel without having to check whether the channel actually supports permissions, such as in the case of threads.
 
 Of course, if you have a channel type that already supports `IPermissionContainer`, you don't need this getter.
 
@@ -103,16 +103,16 @@ JDA v5 provides type-trimmed channel managers, which provide only the setters th
 
 [`StageChannel`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/concrete/StageChannel.html) and [`NewsChannel`](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/concrete/NewsChannel.html) were previously variants of `VoiceChannel` and `TextChannel`. These are now their own independant entities. This comes with a number of changes:
 
-- `ChannelAction#setNews` has been removed in favor of `ChannelAction.setType`
-- `ChannelManager#getType` was removed in favor of `ChannelManager#getChannel()#getType`
-- `ChannelManager#setNews` has been removed in favor of `ChannelManager#setType`
-- `TextChannel#crosspostMessage` was removed in favor of `NewsChannel#crosspostMessage`
-- `TextChannel#follow` has been removed in favor of `NewsChannel#follow`
-- `TextChannel#isNews` has been removed
+- `ChannelAction#setNews` is replaced by `ChannelAction.setType`
+- `ChannelManager#getType` is replaced by `ChannelManager#getChannel()#getType`
+- `ChannelManager#setNews` is replaced by `ChannelManager#setType`
+- `TextChannel#crosspostMessage` is replaced by `NewsChannel#crosspostMessage`
+- `TextChannel#follow` is replaced by `NewsChannel#follow`
+- `TextChannel#isNews` was removed
 
 ### Other Changes
 
-- `StoreChannel` has been removed
+- `StoreChannel` was removed
 - `PrivateChannel#getUser` is now nullable
 - `MessageChannel#getLatestMessageId` and `MessageChannel#getLatestMessageIdLong` no longer change to null if the message was deleted
 
@@ -120,12 +120,12 @@ JDA v5 provides type-trimmed channel managers, which provide only the setters th
 
 A number of permissions have been renamed, with one permission being removed entirely.
 
-- `Permission.MANAGE_EMOTES` was renamed to `Permission.MANAGE_EMOTES_AND_STICKERS`
-- `Permission.MESSAGE_READ` has been removed in favor of `Permission.VIEW_CHANNEL`
-- `Permission.MESSAGE_WRITE` was renamed to `Permission.MESSAGE_SEND`
-- `Permission.USE_SLASH_COMMANDS` was renamed to `Permission.USE_APPLICATION_COMMANDS`
-- `Permission.USE_PUBLIC_THREADS` was renamed to `Permission.CREATE_PUBLIC_THREADS`
-- `Permission.USE_PRIVATE_THREADS` was renamed to `Permission.CREATE_PRIVATE_THREADS`
+- `Permission.MANAGE_EMOTES` renamed to `Permission.MANAGE_EMOTES_AND_STICKERS`
+- `Permission.MESSAGE_WRITE` renamed to `Permission.MESSAGE_SEND`
+- `Permission.USE_SLASH_COMMANDS` renamed to `Permission.USE_APPLICATION_COMMANDS`
+- `Permission.USE_PUBLIC_THREADS` renamed to `Permission.CREATE_PUBLIC_THREADS`
+- `Permission.USE_PRIVATE_THREADS` renamed to `Permission.CREATE_PRIVATE_THREADS`
+- `Permission.MESSAGE_READ` was removed in favor of `Permission.VIEW_CHANNEL`
 
 ## Event Changes
 
@@ -141,7 +141,6 @@ All message event types for guild messages have been removed. Examples of these 
 - `<Context>MessageDeleteEvent` (ex: `GuildMessageDeleteEvent`)
 - `<Context>MessageEmbedEvent` (ex: `GuildMessageEmbedEvent`)
 - `<Context>MessageReaction<X>Event` (ex: `GuildMessageReactionAddEvent`)
-- etc
 
 Instead, you should use the unified versions of these events:
 
@@ -150,9 +149,8 @@ Instead, you should use the unified versions of these events:
 - `MessageUpdatedEvent`
 - `MessageDeletedEvent`
 - `MessageReaction<X>Event` (ex: `MessageReactionAddEvent`)
-- etc
 
-You can check if a message is from a `Guild` by using `Message#isFromGuild()`.
+You can check if a message is from a `Guild` by using `Message#isFromGuild`.
 
 ### Changes to Specifying GatewayIntents from Event Types
 
@@ -164,9 +162,9 @@ All events that update the gateway session of a bot now extend a common [`Generi
 
 Some events relating to sessions have been renamed:
 
-- `DisconnectEvent` has been renamed to `SessionDisconnectEvent`
-- `ReconnectedEvent` has been renamed to `SessionRecreateEvent`
-- `ResumedEvent` has been renamed to `SessionResumeEvent`
+- `DisconnectEvent` renamed to `SessionDisconnectEvent`
+- `ReconnectedEvent` renamed to `SessionRecreateEvent`
+- `ResumedEvent` renamed to `SessionResumeEvent`
 
 ### Voice State Events
 
@@ -351,9 +349,9 @@ Handling commands only changed slightly with regards to the way you reply. Previ
 - `IMessageEditCallback`<br>
     Which supports direct message edits and deferred message edits (or no-operation) via `editMessage(String)` and `deferEdit()`
 - `IModalCallback`<br>
-    Which supports choice suggestions for auto-complete interactions via `replyChoices(Command.Choice...)`
-- `IAutoCompleteCallback`<br>
     Which supports replying using a Modal via `replyModal(Modal)`
+- `IAutoCompleteCallback`<br>
+    Which supports choice suggestions for auto-complete interactions via `replyChoices(Command.Choice...)`
 
 If you relied on the abstract `Interaction` type to provide any of these methods, you will have to adjust your code to use these new interfaces instead.
 

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -74,3 +74,50 @@ A number of permissions have been renamed, with one permission being removed ent
 - `Permission.USE_SLASH_COMMANDS` was renamed to `Permission.USE_APPLICATION_COMMANDS`
 - `Permission.USE_PUBLIC_THREADS` was renamed to `Permission.CREATE_PUBLIC_THREADS`
 - `Permission.USE_PRIVATE_THREADS` was renamed to `Permission.CREATE_PRIVATE_THREADS`
+
+## Event Changes
+
+There are several changes related to events.
+
+### Removal of Guild Context Message Events
+
+All message event types for guild messages have been removed. Examples of these are:
+
+- Generic<Context>MessageEvent (ex: GenericGuildMessageEvent)
+- <Context>MessageReceivedEvent (ex: GuildMessageReceivedEvent)
+- <Context>MessageUpdateEvent (ex: GuildMessageUpdateEvent)
+- <Context>MessageDeleteEvent (ex: GuildMessageDeleteEvent)
+- <Context>MessageEmbedEvent (ex: GuildMessageEmbedEvent)
+- <Context>MessageReaction<X>Event (ex: GuildMessageReactionAddEvent)
+- etc
+
+Instead, you should use the unified versions of these events:
+
+- GenericMessageEvent
+- MessageReceivedEvent
+- MessageUpdatedEvent
+- MessageDeletedEvent
+- MessageReaction<X>Event (ex: MessageReactionAddEvent)
+- etc
+
+You can check if a message is from a `Guild` by using `Message#isFromGuild()`.
+
+### Changes to Specifying GatewayIntents from Event Types
+
+With context-specific events being removed (such as `GuildMessageReceivedEvent`), you can no longer use these events to specify `GatewayIntent.GUILD_MESSAGES` or `GatewayIntent.DIRECT_MESSAGE_REACTIONS`. You may supply any of the unified message events, but the functionality will be slightly different. It is not recommended to use `GatewayIntent#fromEvents` if you wish to have finer grain control around intents for messages.
+
+### Session Events
+
+All events that update the gateway session of a bot now extend a common [`GenericSessionEvent`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/events/session/GenericSessionEvent.html). Such events are located within [the `net.dv8tion.jda.api.events.session` pakage](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/events/session/package-summary.html). This also includes `ReadyEvent` and `ShutdownEvent`.
+
+Some events relating to sessions have been renamed:
+
+- `DisconnectEvent` has been renamed to `SessionDisconnectEvent`
+- `ReconnectedEvent` has been renamed to `SessionRecreateEvent`
+- `ResumedEvent` has been renamed to `SessionResumeEvent`
+
+### Voice State Events
+
+`GuildVoiceJoinEvent` and `GuildVoiceLeaveEvent` have both been removed in favor of the unified [`GuildVoiceUpdateEvent`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/events/guild/voice/GuildVoiceUpdateEvent.html).
+
+As an example, to detect when a user leaves a voice channel, you can use `GuildVoiceUpdateEvent#getChannelLeft`. This method will return the channel that the user left, or `null` if the user joined a channel instead.

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -4,33 +4,29 @@ This version utilizes Discord API v10, and includes several breaking changes and
 
 ## Dependency Installation
 
-Before continuing, we should mention that JDA versions are now distributed via [Maven Central](https://mvnrepository.com/artifact/net.dv8tion/JDA/5.0.0-beta.5). You can remove the old `m2.dv8tion.net` resolver from your build files.
+Before continuing, we should mention that JDA versions are now distributed via [Maven Central](https://mvnrepository.com/artifact/net.dv8tion/JDA/latest). You can remove the old `m2.dv8tion.net` resolver from your build files.
 
-### Gradle
+Replace `VERSION` with the latest version ![Maven Version](https://img.shields.io/maven-central/v/net.dv8tion/JDA?color=blue)
 
-Replace `$latest` with this version ![Maven Version](https://img.shields.io/maven-central/v/net.dv8tion/JDA?color=blue)
+=== "Gradle"
+    ```groovy
+    repositories {
+        mavenCentral()
+    }
+    
+    dependencies {
+        implementation("net.dv8tion:JDA:VERSION")
+    }
+    ```
 
-```gradle
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    implementation("net.dv8tion:JDA:$latest")
-}
-```
-
-### Maven
-
-Replace `$latest` with this version ![Maven Version](https://img.shields.io/maven-central/v/net.dv8tion/JDA?color=blue)
-
-```xml
-<dependency>
-    <groupId>net.dv8tion</groupId>
-    <artifactId>JDA</artifactId>
-    <version>$latest</version>
-</dependency>
-```
+=== "Maven"
+    ```xml
+    <dependency>
+      <groupId>net.dv8tion</groupId>
+      <artifactId>JDA</artifactId>
+      <version>VERSION</version>
+    </dependency>
+    ```
 
 ## Additional Resources
 

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -42,6 +42,10 @@ There are several breaking changes to `GuildChannel` and `ChannelManager`. First
 - `net.dv8tion.jda.api.entities.channel.unions`<br>
     Interfaces used for return values, allowing for downcasting into specific types. They also provided shared features of the specific interface they extend.
 
+### Channel Return Types
+
+A lot of classes in JDA used to have specific getters for each channel type, for instance messages had `getTextChannel()` and `getPrivateChannel()`. The goal was to allow easy conversion to concrete types that have more functionality than their abstract counterpart (such as `MessageChannel`). We've introduced new **Channel Union** interfaces to deal with this problem in a more elegant way. Instead of using `foo.getTextChannel()`, you now use `foo.getChannel().asTextChannel()`. The `getChannel()` method now often returns a specific **Union** type such as `MessageChannelUnion`, which doubles as the abstract implementation for `MessageChannel` (allows to send messages) and also downcasting via various `asX()` methods.
+
 ### New Channel Attribute Interfaces
 
 `GuildChannel` now implements `getGuild` and `getManager` *only*. It's meant to serve as a generic type to hold channels from guilds.

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -1,3 +1,22 @@
+<style>
+:root {
+    --md-tasklist-icon: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m330 768 150-150 150 150 42-42-150-150 150-150-42-42-150 150-150-150-42 42 150 150-150 150 42 42Zm150 208q-82 0-155-31.5t-127.5-86Q143 804 111.5 731T80 576q0-83 31.5-156t86-127Q252 239 325 207.5T480 176q83 0 156 31.5T763 293q54 54 85.5 127T880 576q0 82-31.5 155T763 858.5q-54 54.5-127 86T480 976Z"/></svg>');
+    --md-tasklist-icon--checked: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m346 996-76-130-151-31 17-147-96-112 96-111-17-147 151-31 76-131 134 62 134-62 77 131 150 31-17 147 96 111-96 112 17 147-150 31-77 130-134-62-134 62Zm91-287 227-225-45-41-182 180-95-99-46 45 141 140Z"/></svg>');
+}
+
+.md-typeset [type="checkbox"]:checked + .task-list-indicator:before {
+    background-color: #c3c3c3;
+}
+
+.md-typeset [type="checkbox"]:not(:checked) + .task-list-indicator:before {
+    background-color: #e45050;
+}
+
+.tabbed-set label.task-list-control {
+    margin: 0 0em;
+}
+</style>
+
 # Migration Guide 4.X to 5.X
 
 This version utilizes Discord API v10, and includes several breaking changes and improvements.

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -1,21 +1,6 @@
-<style>
-:root {
-    --md-tasklist-icon: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m330 768 150-150 150 150 42-42-150-150 150-150-42-42-150 150-150-150-42 42 150 150-150 150 42 42Zm150 208q-82 0-155-31.5t-127.5-86Q143 804 111.5 731T80 576q0-83 31.5-156t86-127Q252 239 325 207.5T480 176q83 0 156 31.5T763 293q54 54 85.5 127T880 576q0 82-31.5 155T763 858.5q-54 54.5-127 86T480 976Z"/></svg>');
-    --md-tasklist-icon--checked: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m346 996-76-130-151-31 17-147-96-112 96-111-17-147 151-31 76-131 134 62 134-62 77 131 150 31-17 147 96 111-96 112 17 147-150 31-77 130-134-62-134 62Zm91-287 227-225-45-41-182 180-95-99-46 45 141 140Z"/></svg>');
-}
-
-.md-typeset [type="checkbox"]:checked + .task-list-indicator:before {
-    background-color: #c3c3c3;
-}
-
-.md-typeset [type="checkbox"]:not(:checked) + .task-list-indicator:before {
-    background-color: #e45050;
-}
-
-.tabbed-set label.task-list-control {
-    margin: 0 0em;
-}
-</style>
+---
+template: migration-v5.html
+---
 
 # Migration Guide 4.X to 5.X
 

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -306,3 +306,23 @@ Handling commands only changed slightly with regards to the way you reply. Previ
 If you relied on the abstract `Interaction` type to provide any of these methods, you will have to adjust your code to use these new interfaces instead.
 
 You can find more explanations and examples in the dedicated [Interactions Wiki Page](/using-jda/interactions/).
+
+### Command Permissions/Privileges
+
+Discord has changed how command permissions work. Instead of limiting commands to specific roles and users on a per-guild basis, you set required permissions on each command. For instance, a ban command would require `Permission.BAN_MEMBERS`:
+
+```java
+commands.addCommands(
+    Commands.slash("ban", "Ban a user from this server. Requires permission to ban users.")
+        .addOption(USER, "user", "The user to ban", true)
+        .addOptions(new OptionData(INTEGER, "del_days", "Delete messages from the past days.")
+            .setRequiredRange(0, 7)) // Only allow values between 0 and 7 (inclusive)
+        .addOptions(new OptionData(STRING, "reason", "The ban reason to use (default: Banned by <user>)"))
+        // This way the command can only be executed from a guild, and not DMs
+        .setGuildOnly(true)
+        // Only members with the BAN_MEMBERS permission are going to see this command
+        .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.BAN_MEMBERS))
+)
+```
+
+You can also limit it to administrators with `DefaultMemberPermissions.DISABLED`.

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -12,3 +12,24 @@ The ones that are not checked do not support it yet. You should check that every
 - [ ] [jda-nas](https://github.com/sedmelluq/jda-nas)
     - [ ] [udpqueue.rs](https://github.com/MinnDevelopment/udpqueue.rs) (for minimal Rust bindings)
 - [ ] [JDA-Utilities](https://github.com/JDA-Applications/JDA-Utilities)
+
+## Channel Rework
+
+There are several breaking changes to `GuildChannel` and `ChannelManager`
+
+### New Channel Attribute Interfaces
+
+`GuildChannel` now implements `getGuild` and `getManager` *only*. It's meant to serve as a generic type to hold channels from guilds.
+
+Specific channel attributes, such as slow mode, permissions, etc have been split into several interfaces. These interfaces can be found in [the `net.dv8tion.jda.api.entities.channel.attribute` package](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/attribute/package-summary.html). Each interface in this package extends `GuildChannel`.
+
+### Independant Stage Channel and News Channel Entities
+
+[`StageChannel`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/concrete/StageChannel.html) and [`NewsChannel`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/concrete/NewsChannel.html) were previously variants of `VoiceChannel` and `TextChannel`. These are now their own independant entities. This comes with a number of changes:
+
+- `ChannelAction#setNews` has been removed in favor of `ChannelAction.setType`
+- `ChannelManager#getType` was removed in favor of `ChannelManager#getChannel()#getType`
+- `ChannelManager#setNews` has been removed in favor of `ChannelManager#setType`
+- `TextChannel#crosspostMessage` was removed in favor of `NewsChannel#crosspostMessage`
+- `TextChannel#follow` has been removed in favor of `NewsChannel#follow`
+- `TextChannel#isNews` has been removed

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -189,7 +189,7 @@ The following intents have been renamed to align with the API name convention:
 
 ### Chunking and Caching
 
-If you used `ChunkingFilter.ALL` in the past, JDA would automatically also cache all those members it chunked. However, this is not a very flexible rule and we changed this behavior. Instead, the `MemberCachePolicy` will control which members to keep cached after chunking.
+If you used `ChunkingFilter.ALL` in the past, JDA would automatically also cache all those members it chunked. However, this is not a very flexible rule, and we changed this behavior. Instead, the `MemberCachePolicy` will control which members to keep cached after chunking.
 
 ## Sticker and Emoji Rework
 
@@ -267,7 +267,7 @@ This also means that all methods from `message.editMessage(...)` are consistent 
 
 The old `sendFile(...)`/`replyFile(...)` overloads available on `MessageChannel` and interactions has been replaced by a single `sendFiles(...)` method. This new method accepts the `FileUpload` type, which also supports file descriptions (alt text) via `setDescription(...)`. For example, old code such as `sendFile(data, name, AttachmentOption.SPOILER)` is replaced with `sendFiles(FileUpload.fromData(data, name).asSpoiler())`.
 
-Due to changes in the Discord API v10, you can no longer add files to messages without replacing all existing attachments. We could previously support methods such as `MessageAction#addFile` for editing messages, which is no longer possible in API v10. Instead you **must** replace the entire list of attachments, using `MessageEditAction#setAttachments`. Here is an example:
+Due to changes in the Discord API v10, you can no longer add files to messages without replacing all existing attachments. We could previously support methods such as `MessageAction#addFile` for editing messages, which is no longer possible in API v10. Instead, you **must** replace the entire list of attachments, using `MessageEditAction#setAttachments`. Here is an example:
 
 ```java
 // Here "message" is an instance of the Message interface
@@ -287,7 +287,7 @@ message.editMessage("New content")
 
 ### Message Splitting
 
-The old `MessageBuilder#buildAll` has been removed from the builder classes. Instead you can now use the new `SplitUtil` utility class to split any string. For example:
+The old `MessageBuilder#buildAll` has been removed from the builder classes. Instead, you can now use the new `SplitUtil` utility class to split any string. For example:
 
 **Old:**
 
@@ -327,7 +327,7 @@ Additionally, the return type of `Mentions#getChannels` has been adjusted to ret
 
 ## Interaction Rework
 
-To properly handle **Context Menu** and **Auto-complete** interactions, we reworked some of the interaction types. This includes numerous breaking changes to naming conventions and package layouts.
+To properly handle **Context Menu** and **Auto-complete** interactions, we reworked some interaction types. This includes numerous breaking changes to naming conventions and package layouts.
 
 ### Naming Changes
 
@@ -346,7 +346,7 @@ To properly handle **Context Menu** and **Auto-complete** interactions, we rewor
 
 With the introduction of **Context Menu Commands**, we changed how commands are created. Instead of `new CommandData(...)`, you now create a slash command using the factory method `Commands.slash(...)`, which returns a `SlashCommandData` instance that has the familiar methods. You can now also use `Commands.user(...)` and `Commands.message(...)` to create new context menu commands which appear in the right-click menu option named **Apps** in the Discord Client.
 
-Handling commands only changed slightly with regards to the way you reply. Previously, all `Interaction` types had a `reply(...)` or `deferReply(...)` method. This has been changed due to new interaction types like **AutoCompleteInteraction** and **ModalInteraction**. Now, each concrete interaction type implements specific **callback** interfaces such as:
+Handling commands only changed slightly with regard to the way you reply. Previously, all `Interaction` types had a `reply(...)` or `deferReply(...)` method. This has been changed due to new interaction types like **AutoCompleteInteraction** and **ModalInteraction**. Now, each concrete interaction type implements specific **callback** interfaces such as:
 
 - `IReplyCallback`<br>
     Which supports direct message replies and deferred message replies via `reply(String)` and `deferReply()`
@@ -421,7 +421,7 @@ Kick reasons have also been moved into the `reason(...)` method, for example `gu
 
 ## Managers are no longer persistent
 
-All getters for managers in JDA used to be lazy-idempotent, such that calling `getManager()` twice would return the same instance. This has been removed to reduce memory usage an complexity. If you previously relied on this behavior, you will need to adjust your code.
+All getters for managers in JDA used to be lazy-idempotent, such that calling `getManager()` twice would return the same instance. This has been removed to reduce memory usage and complexity. If you previously relied on this behavior, you will need to adjust your code.
 
 **Old:**
 

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -2,6 +2,14 @@
 
 This version utilizes Discord API v10, and includes several breaking changes and improvements.
 
+## Additional Resources
+
+This migration guide does not include every single detail and does not focus on any new features available in JDA 5, such as [ThreadChannels](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/concrete/ThreadChannel.html). Here are some useful resources to learn more if you are curious about all the new things we added:
+
+- [Examples](https://github.com/DV8FromTheWorld/JDA/tree/master/src/examples/java)
+- [JDA 5 Javadocs](https://ci.dv8tion.net/job/JDA5/javadoc/)
+- [Releases](https://github.com/DV8FromTheWorld/JDA/releases)
+
 ## Extensions That Support 5.X
 
 Here is a list of known extensions that support 5.X.
@@ -11,6 +19,7 @@ The ones that are not checked do not support it yet. You should check that every
 - [x] [LavaPlayer](https://github.com/sedmelluq/lavaplayer)
 - [x] [jda-nas](https://github.com/sedmelluq/jda-nas)
     - [x] [udpqueue.rs](https://github.com/MinnDevelopment/udpqueue.rs) (for minimal Rust bindings)
+- [x] [jda-ktx](https://github.com/MinnDevelopment/jda-ktx)
 - [ ] [JDA-Utilities](https://github.com/JDA-Applications/JDA-Utilities)
 
 ## Introduction of Message Content Privileged Intent

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -34,6 +34,12 @@ Specific channel attributes, such as slow mode, permissions, etc have been split
 - `TextChannel#follow` has been removed in favor of `NewsChannel#follow`
 - `TextChannel#isNews` has been removed
 
+### Other Changes
+
+- `StoreChannel` has been removed
+- `PrivateChannel#getUser` is now nullable
+- `MessageChannel#getLatestMessageId` and `MessageChannel#getLatestMessageIdLong` no longer change to null if the message was deleted
+
 ## Permission Changes
 
 A number of permissions have been renamed, with one permission being removed entirely.

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -23,6 +23,12 @@ There are several breaking changes to `GuildChannel` and `ChannelManager`
 
 Specific channel attributes, such as slow mode, permissions, etc have been split into several interfaces. These interfaces can be found in [the `net.dv8tion.jda.api.entities.channel.attribute` package](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/attribute/package-summary.html). Each interface in this package extends `GuildChannel`.
 
+### Type-Trimmed Channel Managers
+
+In JDA v4, `GuildChannel#getManager` returned a `ChannelManager` that gave every possible setter for every channel type. This caused for `UnsupportedOperationException` or `IllegalStateException` to be thrown in some cases, such as calling `setBitrate` on a `TextChannel`.
+
+JDA v5 provides type-trimmed channel managers, which provide only the setters that we know *for sure* can work on the given channel. Each of these managers can be found in [the `net.dv8tion.jda.api.managers.channel` package](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/managers/channel/package-summary.html). These all follow the same implement/extension hierarchy as the channels do and map 1:1.
+
 ### Independant Stage Channel and News Channel Entities
 
 [`StageChannel`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/concrete/StageChannel.html) and [`NewsChannel`](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/concrete/NewsChannel.html) were previously variants of `VoiceChannel` and `TextChannel`. These are now their own independant entities. This comes with a number of changes:

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -191,6 +191,6 @@ You also now use `Emoji` instances for reactions. What was previously `message.a
 - `Emoji.fromCustom`<br>
     Creates a `CustomEmoji` instance from the provided name and id.
 - `Emoji.fromFormatted`<br>
-    parses emoji instances from markdown such as `"<:minn:12345581261712671>"` and also supports unicode such as `"😃"` or codepoint notation `"U+1F602"`. This returns a `EmojiUnion` instance, which can be either custom or unicode.
+    Parses emoji instances from markdown such as `"<:minn:12345581261712671>"` and also supports unicode such as `"😃"` or codepoint notation `"U+1F602"`. This returns a `EmojiUnion` instance, which can be either custom or unicode.
 
 You can see the full list of breaking changes in [#2117](https://github.com/DV8FromTheWorld/JDA/pull/2117).

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -287,6 +287,7 @@ To properly handle **Context Menu** and **Auto-complete** interactions, we rewor
 - Introduced **new** `Component` interface to abstract both layouts and items.
 - `MessageType.APPLICATION_COMMAND` renamed to `MessageType.SLASH_COMMAND` (we now also have `MessageType.CONTEXT_COMMAND`)
 - `InteractionType.SLASH_COMMAND` renamed to `InteractionType.COMMAND` (we now also have `InteractionType.COMMAND_AUTOCOMPLETE`)
+- `SlashCommandEvent#getCommandPath` renamed to `CommandInteractionPayload#getFullCommandName` (it also now uses spaces instead of slashes, e.g. `mod/ban` is now `mod ban`)
 
 ### Creating and Handling Commands
 

--- a/docs/introduction/migration-v4-v5.md
+++ b/docs/introduction/migration-v4-v5.md
@@ -23,6 +23,12 @@ There are several breaking changes to `GuildChannel` and `ChannelManager`
 
 Specific channel attributes, such as slow mode, permissions, etc have been split into several interfaces. These interfaces can be found in [the `net.dv8tion.jda.api.entities.channel.attribute` package](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/attribute/package-summary.html). Each interface in this package extends `GuildChannel`.
 
+### Permission Access Changes
+
+With JDA v5 introducing a more butchered down `GuildChannel` interface, `GuildChannel#getPermissionContainer() : IPermissionContainer` has been introduced to make accessing permissions easier. This allows for users to confidently access the entity that dictates the permissions for a given channel without having to check whether the channel actually supports permissions, such as in the case of threads.
+
+Of course, if you have a channel type that already supports `IPermissionContainer`, you don't need this getter.
+
 ### Type-Trimmed Channel Managers
 
 In JDA v4, `GuildChannel#getManager` returned a `ChannelManager` that gave every possible setter for every channel type. This caused for `UnsupportedOperationException` or `IllegalStateException` to be thrown in some cases, such as calling `setBitrate` on a `TextChannel`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ edit_uri: ../JDA-Website/edit/master/docs/
 extra_css:
 - 'assets/stylesheets/colors.css'
 - 'assets/stylesheets/frontpage.css'
+- 'assets/stylesheets/tasklists.css'
 
 markdown_extensions:
   - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
     - List of Events: introduction/events-list.md
     - FAQ: introduction/faq.md
     - Migration V3 -> V4: introduction/migration-v3-v4.md
+    - Migration V4 -> V5: introduction/migration-v4-v5.md
   - Setup:
     - IntelliJ IDEA Setup: setup/intellij.md
     - Eclipse Setup: setup/eclipse.md

--- a/overrides/migration-v5.html
+++ b/overrides/migration-v5.html
@@ -6,7 +6,7 @@
 }
 
 .md-typeset [type="checkbox"]:checked + .task-list-indicator:before {
-    background-color: #c3c3c3;
+    background-color: #00e676;
 }
 
 .md-typeset [type="checkbox"]:not(:checked) + .task-list-indicator:before {

--- a/overrides/migration-v5.html
+++ b/overrides/migration-v5.html
@@ -1,16 +1,20 @@
 {% extends "main.html" %}
 <style>
 :root {
-    --md-tasklist-icon: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m330 768 150-150 150 150 42-42-150-150 150-150-42-42-150 150-150-150-42 42 150 150-150 150 42 42Zm150 208q-82 0-155-31.5t-127.5-86Q143 804 111.5 731T80 576q0-83 31.5-156t86-127Q252 239 325 207.5T480 176q83 0 156 31.5T763 293q54 54 85.5 127T880 576q0 82-31.5 155T763 858.5q-54 54.5-127 86T480 976Z"/></svg>');
-    --md-tasklist-icon--checked: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m346 996-76-130-151-31 17-147-96-112 96-111-17-147 151-31 76-131 134 62 134-62 77 131 150 31-17 147 96 111-96 112 17 147-150 31-77 130-134-62-134 62Zm91-287 227-225-45-41-182 180-95-99-46 45 141 140Z"/></svg>');
+    --md-custom-tasklist-icon--unchecked: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m330 768 150-150 150 150 42-42-150-150 150-150-42-42-150 150-150-150-42 42 150 150-150 150 42 42Zm150 208q-82 0-155-31.5t-127.5-86Q143 804 111.5 731T80 576q0-83 31.5-156t86-127Q252 239 325 207.5T480 176q83 0 156 31.5T763 293q54 54 85.5 127T880 576q0 82-31.5 155T763 858.5q-54 54.5-127 86T480 976Z"/></svg>');
+    --md-custom-tasklist-icon--checked: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m346 996-76-130-151-31 17-147-96-112 96-111-17-147 151-31 76-131 134 62 134-62 77 131 150 31-17 147 96 111-96 112 17 147-150 31-77 130-134-62-134 62Zm91-287 227-225-45-41-182 180-95-99-46 45 141 140Z"/></svg>');
+    --md-custom-color--verified: #00e676;
+    --md-custom-color--unverified: #e45050;
 }
 
 .md-typeset [type="checkbox"]:checked + .task-list-indicator:before {
-    background-color: #00e676;
+    background-color: var(--md-custom-color--verified);
+    mask-image: var(--md-custom-tasklist-icon--checked);
 }
 
 .md-typeset [type="checkbox"]:not(:checked) + .task-list-indicator:before {
-    background-color: #e45050;
+    background-color: var(--md-custom-color--unverified);
+    mask-image: var(--md-custom-tasklist-icon--unchecked);
 }
 
 .tabbed-set label.task-list-control {

--- a/overrides/migration-v5.html
+++ b/overrides/migration-v5.html
@@ -1,0 +1,19 @@
+{% extends "main.html" %}
+<style>
+:root {
+    --md-tasklist-icon: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m330 768 150-150 150 150 42-42-150-150 150-150-42-42-150 150-150-150-42 42 150 150-150 150 42 42Zm150 208q-82 0-155-31.5t-127.5-86Q143 804 111.5 731T80 576q0-83 31.5-156t86-127Q252 239 325 207.5T480 176q83 0 156 31.5T763 293q54 54 85.5 127T880 576q0 82-31.5 155T763 858.5q-54 54.5-127 86T480 976Z"/></svg>');
+    --md-tasklist-icon--checked: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m346 996-76-130-151-31 17-147-96-112 96-111-17-147 151-31 76-131 134 62 134-62 77 131 150 31-17 147 96 111-96 112 17 147-150 31-77 130-134-62-134 62Zm91-287 227-225-45-41-182 180-95-99-46 45 141 140Z"/></svg>');
+}
+
+.md-typeset [type="checkbox"]:checked + .task-list-indicator:before {
+    background-color: #c3c3c3;
+}
+
+.md-typeset [type="checkbox"]:not(:checked) + .task-list-indicator:before {
+    background-color: #e45050;
+}
+
+.tabbed-set label.task-list-control {
+    margin: 0 0em;
+}
+</style>


### PR DESCRIPTION
This PR creates a wiki page for migrating from JDA v4 to JDA v5.

This new page utilizes the same approach as the [v3 -> v4 migration page](https://jda.wiki/introduction/migration-v3-v4), using the changes mentioned in the `#jda5-changes` channel

TODO (in no particular order):
- [x] Supported extensions
- [x] API v10
- [x] Message Content Intent
- [x] Message Send/Edit Rework
- [x] Interaction rework
- [x] Command Permissions v2
- [x] Command Path Changes
- [x] `GuildChannel` rework
- [x] `ChannelManager` type trimming
- [x] Event Changes (including unification, renaming of events)
- [x] Session Event Changes
- [x] Permission Changes
- [x] Mentions rework
- [x] Introduction of `UserSnowflake`
- [x] Emote rework
- [x] Intent and cache changes
